### PR TITLE
macBufferを4MB→128MBに変更

### DIFF
--- a/src/github/data/fetcher.ts
+++ b/src/github/data/fetcher.ts
@@ -116,7 +116,7 @@ export async function fetchGitHubData({
         // Use git hash-object to compute the SHA for the current file content
         const sha = execSync(`git hash-object "${file.path}"`, {
           encoding: "utf-8",
-          maxBuffer: 1024 * 1024 * 4, // ERR_CHILD_PROCESS_STDIO_MAXBUFFERに対応 デフォルト値は1024 * 1024 (1MB)
+          maxBuffer: 1024 * 1024 * 128, // ClaudeCodeActions用に128MBに拡大 (デフォルト1MB→高負荷対応)
         }).trim();
         return {
           ...file,


### PR DESCRIPTION
GitHub Actionsランナーのリソースから考えると128MBでも全然余裕なようなので変更しています。